### PR TITLE
Remove unused error messages

### DIFF
--- a/users/router.js
+++ b/users/router.js
@@ -31,7 +31,7 @@ const basicStrategy = new BasicStrategy((username, password, callback) => {
         return callback(null, user)
       }
     })
-    .catch(err => callback(err);
+    .catch(err => callback(err));
 });
 
 passport.use(basicStrategy);

--- a/users/router.js
+++ b/users/router.js
@@ -28,7 +28,7 @@ const basicStrategy = new BasicStrategy((username, password, callback) => {
         return callback(null, false);
       }
       else {
-        return callback(null, user)
+        return callback(null, user);
       }
     })
     .catch(err => callback(err));

--- a/users/router.js
+++ b/users/router.js
@@ -19,18 +19,19 @@ const basicStrategy = new BasicStrategy((username, password, callback) => {
     .then(_user => {
       user = _user;
       if (!user) {
-        return callback(null, false, {message: 'Incorrect username'});
+        return callback(null, false);
       }
       return user.validatePassword(password);
     })
     .then(isValid => {
       if (!isValid) {
-        return callback(null, false, {message: 'Incorrect password'});
+        return callback(null, false);
       }
       else {
         return callback(null, user)
       }
-    });
+    })
+    .catch(err => callback(err);
 });
 
 passport.use(basicStrategy);


### PR DESCRIPTION
Bring in line with example in passportjs docs: http://passportjs.org/docs/basic-digest#Basic

In response to student who reached out saying that the messages for incorrect username/password weren't coming through.